### PR TITLE
Allow failures on Julia nightly to get rid of the build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os:
 julia:
   - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 after_success:


### PR DESCRIPTION
Make the build icon in the readme green again.