### PR TITLE
WIP: Container-stable linear algebra

### DIFF
--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -1,4 +1,4 @@
-undef##
+##
 # Represent a banded matrix
 # [ a_11 a_12
 #   a_21 a_22 a_23
@@ -239,11 +239,23 @@ Creates a banded matrix similar to the input. Convenience function that can
 take either a matrix or a banded matrix and return a banded matrix, where the
 underlying container has the same matrix or container type as the input.
 """
-similar_banded(bm::AbstractBandedMatrix, args...) = similar(bm, args...)
-function similar_banded(mat::AbstractMatrix, args...)
-    C = typeof(similar(mat, 0, 0))
-    n, m = size(mat)
-    u, l = bandwidth(mat)
+function similar_banded(mat::AbstractMatrix, T::Type=eltype(mat), 
+                         n::Integer=size(mat, 1), m::Integer=size(mat, 2),
+                         l::Integer=bandwidth(mat, 1), u::Integer=bandwidth(mat, 2))
+    _similar_banded(mat, T, n, m, l, u)
+end 
+similar_banded(bm::AbstractMatrix, n::Integer, m::Integer) = similar_banded(bm, eltype(bm), n, m)
+similar_banded(bm::AbstractMatrix, n::Integer, m::Integer, l::Integer, u::Integer) =
+    similar_banded(bm, eltype(bm), n, m, l, u)
+
+function _similar_banded(mat::Union{BandedMatrix, BandedSubBandedMatrix},
+                        T::Type, n::Integer, m::Integer, l::Integer,
+                        u::Integer)
+    similar(mat, T, n, m, l)
+end
+function _similar_banded(mat::AbstractMatrix, T::Type, n::Integer, m::Integer,
+                         l::Integer, u::Integer)
+    C = typeof(similar(mat, T, 0, 0))
     BandedMatrix{eltype(C), C}(undef, n, m, u, l)
 end
 

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -231,7 +231,21 @@ end
 Base.similar(bm::AbstractBandedMatrix, n::Integer, m::Integer) = similar(bm, eltype(bm), n, m)
 Base.similar(bm::AbstractBandedMatrix, n::Integer, m::Integer, l::Integer, u::Integer) =
     similar(bm, eltype(bm), n, m, l, u)
+"""
+    similar_banded(bm::AbstractBandedMatrix, [T::Type], [n::Integer, m::Integer, [l::Integer, u::Integer]])
+    similar_banded(bm::AbstractMatrix, [T::Type], [n::Integer, m::Integer, [l::Integer, u::Integer]])
 
+Creates a banded matrix similar to the input. Convenience function that can
+take either a matrix or a banded matrix and return a banded matrix, where the
+underlying container has the same matrix or container type as the input.
+"""
+similar_banded(bm::AbstractBandedMatrix, args...) = similar(bm, args...)
+function similar_banded(mat::AbstractMatrix, args...)
+    C = typeof(similar(mat, 0, 0))
+    n, m = size(mat)
+    u, l = bandwidth(mat)
+    BandedMatrix{eltype(C), C}(undef, n, m, u, l)
+end
 
 function _shift(bm::BandedSubBandedMatrix)
     kr,jr=parentindices(bm)

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -228,9 +228,9 @@ function Base.similar(bm::BandedMatrix, T::Type=eltype(bm),
     _BandedMatrix(data, n, l, u)
 end
 
-Base.similar(bm::AbstractBandedMatrix, n::Integer, m::Integer) = similar(bm, eltype(bm), m, n)
+Base.similar(bm::AbstractBandedMatrix, n::Integer, m::Integer) = similar(bm, eltype(bm), n, m)
 Base.similar(bm::AbstractBandedMatrix, n::Integer, m::Integer, l::Integer, u::Integer) =
-    similar(bm, eltype(bm), m, n, l, u)
+    similar(bm, eltype(bm), n, m, l, u)
 
 
 function _shift(bm::BandedSubBandedMatrix)
@@ -730,7 +730,7 @@ else
 end
 
 function Base.transpose(B::BandedMatrix)
-    Bt = BandedMatrix(Zeros{eltype(B)}(size(B,2),size(B,1)), (B.u,B.l))
+    Bt = similar(B, size(B,2), size(B,1), B.u, B.l)
     for j = 1:size(B,2), k = colrange(B,j)
        Bt[j,k]=B[k,j]
     end
@@ -738,7 +738,7 @@ function Base.transpose(B::BandedMatrix)
 end
 
 function Base.ctranspose(B::BandedMatrix)
-    Bt=BandedMatrix(Zeros{eltype(B)}(size(B,2),size(B,1)), (B.u,B.l))
+    Bt = similar(B, size(B,2), size(B,1), B.u, B.l)
     for j = 1:size(B,2), k = colrange(B,j)
        Bt[j,k]=conj(B[k,j])
     end

--- a/src/generic/interface.jl
+++ b/src/generic/interface.jl
@@ -440,19 +440,24 @@ if VERSION < v"0.7-"
             Base.copy!(dest::$Typ1, src::$Typ2) = BandedMatrices.banded_copy!(dest,src)
             Base.BLAS.axpy!(a::Number, X::$Typ1, Y::$Typ2) = BandedMatrices.banded_axpy!(a, X, Y)
 
-            function Base.:+(A::$Typ1{T}, B::$Typ2{V}) where {T,V}
+            function Base.:+(A::$Typ1, B::$Typ2)
                 n, m = size(A)
-                ret = BandedMatrices.BandedMatrix(BandedMatrices.Zeros{promote_type(T,V)}(n, m), BandedMatrices.sumbandwidths(A, B))
-                axpy!(one(T), A, ret)
-                axpy!(one(V), B, ret)
+                u, l = sumbandwidths(A, B)
+                T = promote_type(eltype(A), eltype(B))
+                ret = fill!(similar_banded(B, n, m, u, l), zero(eltype(B)))
+                axpy!(one(eltype(A)), A, ret)
+                axpy!(one(eltype(B)), B, ret)
                 ret
             end
 
-            function Base.:-(A::$Typ1{T}, B::$Typ2{V}) where {T,V}
+            function Base.:-(A::$Typ1, B::$Typ2)
                 n, m=size(A)
-                ret = BandedMatrices.BandedMatrix(BandedMatrices.Zeros{promote_type(T,V)}(n, m), BandedMatrices.sumbandwidths(A, B))
-                axpy!(one(T),  A, ret)
-                axpy!(-one(V), B, ret)
+                u, l = sumbandwidths(A, B)
+                T = promote_type(eltype(A), eltype(B))
+                ret = fill!(similar_banded(B, n, m, u, l), zero(eltype(B)))
+                println("$(size(A)) == $(size(ret)) == $(size(similar(B, n, m, u, l)))")
+                axpy!(one(eltype(A)),  A, ret)
+                axpy!(-one(eltype(B)), B, ret)
                 ret
             end
 

--- a/src/generic/interface.jl
+++ b/src/generic/interface.jl
@@ -444,18 +444,17 @@ if VERSION < v"0.7-"
                 n, m = size(A)
                 u, l = sumbandwidths(A, B)
                 T = promote_type(eltype(A), eltype(B))
-                ret = fill!(similar_banded(B, n, m, u, l), zero(eltype(B)))
+                ret = fill!(similar_banded(B, T, n, m, u, l), zero(eltype(B)))
                 axpy!(one(eltype(A)), A, ret)
                 axpy!(one(eltype(B)), B, ret)
                 ret
             end
 
             function Base.:-(A::$Typ1, B::$Typ2)
-                n, m=size(A)
+                n, m = size(A)
                 u, l = sumbandwidths(A, B)
                 T = promote_type(eltype(A), eltype(B))
-                ret = fill!(similar_banded(B, n, m, u, l), zero(eltype(B)))
-                println("$(size(A)) == $(size(ret)) == $(size(similar(B, n, m, u, l)))")
+                ret = fill!(similar_banded(B, T, n, m, u, l), zero(eltype(B)))
                 axpy!(one(eltype(A)),  A, ret)
                 axpy!(-one(eltype(B)), B, ret)
                 ret

--- a/src/generic/utils.jl
+++ b/src/generic/utils.jl
@@ -1,6 +1,5 @@
 # BLAS/linear algebra overrides
-
-@inline dot(x...) = LinearAlgebra.dot(x...)
+@inline dot(x...) = Compat.LinearAlgebra.dot(x...)
 @inline dot(M::Int,a::Ptr{T},incx::Int,b::Ptr{T},incy::Int) where {T<:Union{Float64,Float32}} =
     BLAS.dot(M,a,incx,b,incy)
 @inline dot(M::Int,a::Ptr{T},incx::Int,b::Ptr{T},incy::Int) where {T<:Union{ComplexF64,ComplexF32}} =

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -51,31 +51,31 @@ end
     let A = brand(10,12,2,3),B = brand(10,12,3,4)
         @test Matrix(sparse(A)) ≈ Matrix(A)
 
-        to_bjl(A) = convert(BandedMatrix{<:, JLArray}, A)
+        to_bjl(A) = convert(BandedMatrix{<:, MyMatrix}, A)
         @test Matrix(A') ≈ Matrix(A)'
         @test @inferred(transpose(to_bjl(A))) ≈ Matrix(A)'
-        @test (to_bjl(A)').data isa JLArray
+        @test (to_bjl(A)').data isa MyMatrix
         @test Matrix(@inferred(transpose(A))) ≈ transpose(Matrix(A))
         @test Matrix((A+im*A)') ≈ (Matrix(A)+im*Matrix(A))'
         @test Matrix(transpose(A+im*A)) ≈ transpose(Matrix(A)+im*Matrix(A))
-        @test convert(BandedMatrix{<:, JLArray}, A+im*A)' ≈ (Matrix(A)+im*Matrix(A))'
-        @test (convert(BandedMatrix{<:, JLArray}, A+im*A)').data isa JLArray
+        @test convert(BandedMatrix{<:, MyMatrix}, A+im*A)' ≈ (Matrix(A)+im*Matrix(A))'
+        @test (convert(BandedMatrix{<:, MyMatrix}, A+im*A)').data isa MyMatrix
 
         @test Matrix(@inferred(A+B)) ≈ (Matrix(A)+Matrix(B))
         @test Matrix(@inferred(to_bjl(A)+B)) ≈ (Matrix(A)+Matrix(B))
         @test Matrix(@inferred(A+to_bjl(B))) ≈ (Matrix(A)+Matrix(B))
         @test Matrix(@inferred(to_bjl(A)+to_bjl(B))) ≈ (Matrix(A)+Matrix(B))
         @test (to_bjl(A)+B).data isa Matrix
-        @test (A+to_bjl(B)).data isa JLArray
-        @test (to_bjl(A)+to_bjl(B)).data isa JLArray
+        @test (A+to_bjl(B)).data isa MyMatrix
+        @test (to_bjl(A)+to_bjl(B)).data isa MyMatrix
         @test Matrix(@inferred(A-B)) ≈ (Matrix(A)-Matrix(B))
         @test Matrix(@inferred(to_bjl(A)-B)) ≈ (Matrix(A)-Matrix(B))
         @test Matrix(@inferred(to_bjl(A)-to_bjl(B))) ≈ (Matrix(A)-Matrix(B))
         @test Matrix(@inferred(A-to_bjl(B))) ≈ (Matrix(A)-Matrix(B))
         @test (A-B).data isa Matrix
         @test (to_bjl(A)-B).data isa Matrix
-        @test (to_bjl(A)-to_bjl(B)).data isa JLArray
-        @test (A-to_bjl(B)).data isa JLArray
+        @test (to_bjl(A)-to_bjl(B)).data isa MyMatrix
+        @test (A-to_bjl(B)).data isa MyMatrix
 
         @test Matrix(@inferred(A.*B)) ≈ (Matrix(A).*Matrix(B))
     end

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -61,10 +61,23 @@ end
         @test convert(BandedMatrix{<:, JLArray}, A+im*A)' ≈ (Matrix(A)+im*Matrix(A))'
         @test (convert(BandedMatrix{<:, JLArray}, A+im*A)').data isa JLArray
 
-        @test Matrix(A+B) ≈ (Matrix(A)+Matrix(B))
-        @test Matrix(A-B) ≈ (Matrix(A)-Matrix(B))
+        @test Matrix(@inferred(A+B)) ≈ (Matrix(A)+Matrix(B))
+        @test Matrix(@inferred(to_bjl(A)+B)) ≈ (Matrix(A)+Matrix(B))
+        @test Matrix(@inferred(A+to_bjl(B))) ≈ (Matrix(A)+Matrix(B))
+        @test Matrix(@inferred(to_bjl(A)+to_bjl(B))) ≈ (Matrix(A)+Matrix(B))
+        @test (to_bjl(A)+B).data isa Matrix
+        @test (A+to_bjl(B)).data isa JLArray
+        @test (to_bjl(A)+to_bjl(B)).data isa JLArray
+        @test Matrix(@inferred(A-B)) ≈ (Matrix(A)-Matrix(B))
+        @test Matrix(@inferred(to_bjl(A)-B)) ≈ (Matrix(A)-Matrix(B))
+        @test Matrix(@inferred(to_bjl(A)-to_bjl(B))) ≈ (Matrix(A)-Matrix(B))
+        @test Matrix(@inferred(A-to_bjl(B))) ≈ (Matrix(A)-Matrix(B))
+        @test (A-B).data isa Matrix
+        @test (to_bjl(A)-B).data isa Matrix
+        @test (to_bjl(A)-to_bjl(B)).data isa JLArray
+        @test (A-to_bjl(B)).data isa JLArray
 
-        @test Matrix(A.*B) ≈ (Matrix(A).*Matrix(B))
+        @test Matrix(@inferred(A.*B)) ≈ (Matrix(A).*Matrix(B))
     end
 
     ## UniformScaling

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -95,8 +95,8 @@ end
 # banded * vec
 @testset "BandedMatrix * Vector" begin
     let A=brand(10,12,2,3), v=rand(12), w=rand(10)
-        @test A*v ≈ Matrix(A)*v
-        @test A'*w ≈ Matrix(A)'*w
+        @test @inferred(A*v) ≈ Matrix(A)*v
+        @test @inferred(A'*w) ≈ Matrix(A)'*w
     end
 
     let A=brand(Float64,5,3,2,2), v=rand(ComplexF64,3), w=rand(ComplexF64,5)

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -51,10 +51,11 @@ end
     let A = brand(10,12,2,3),B = brand(10,12,3,4)
         @test Matrix(sparse(A)) ≈ Matrix(A)
 
+        to_bjl(A) = convert(BandedMatrix{<:, JLArray}, A)
         @test Matrix(A') ≈ Matrix(A)'
-        @test convert(BandedMatrix{<:, JLArray}, A)' ≈  Matrix(A)'
-        @test (convert(BandedMatrix{<:, JLArray}, A)').data isa JLArray
-        @test Matrix(transpose(A)) ≈ transpose(Matrix(A))
+        @test @inferred(transpose(to_bjl(A))) ≈ Matrix(A)'
+        @test (to_bjl(A)').data isa JLArray
+        @test Matrix(@inferred(transpose(A))) ≈ transpose(Matrix(A))
         @test Matrix((A+im*A)') ≈ (Matrix(A)+im*Matrix(A))'
         @test Matrix(transpose(A+im*A)) ≈ transpose(Matrix(A)+im*Matrix(A))
         @test convert(BandedMatrix{<:, JLArray}, A+im*A)' ≈ (Matrix(A)+im*Matrix(A))'

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -52,9 +52,13 @@ end
         @test Matrix(sparse(A)) ≈ Matrix(A)
 
         @test Matrix(A') ≈ Matrix(A)'
+        @test convert(BandedMatrix{<:, JLArray}, A)' ≈  Matrix(A)'
+        @test (convert(BandedMatrix{<:, JLArray}, A)').data isa JLArray
         @test Matrix(transpose(A)) ≈ transpose(Matrix(A))
         @test Matrix((A+im*A)') ≈ (Matrix(A)+im*Matrix(A))'
         @test Matrix(transpose(A+im*A)) ≈ transpose(Matrix(A)+im*Matrix(A))
+        @test convert(BandedMatrix{<:, JLArray}, A+im*A)' ≈ (Matrix(A)+im*Matrix(A))'
+        @test (convert(BandedMatrix{<:, JLArray}, A+im*A)').data isa JLArray
 
         @test Matrix(A+B) ≈ (Matrix(A)+Matrix(B))
         @test Matrix(A-B) ≈ (Matrix(A)-Matrix(B))

--- a/test/test_subarray.jl
+++ b/test/test_subarray.jl
@@ -30,7 +30,6 @@ import Compat.LinearAlgebra: axpy!
         @test (2.0A[:,1:10]+B[:,1:10]) ≈ axpy!(2.0,view(A,:,1:10),view(B2,:,1:10))
         @test (2.0A[:,1:10]+B[:,1:10]) ≈ B2[:,1:10]
 
-
         B2 = copy(B)
         @test (2.0A[:,:]+B[:,:]) ≈ axpy!(2.0,view(A,:,:),view(B2,:,:))
         @test (2.0A[:,:]+B[:,:]) ≈ B2[:,:]


### PR DESCRIPTION
E.g `BandedMatrix{<:, CLArray} + BandedMatrix{<:, CLArray}`  should yield another `BandedMatrix{<:, CLArray}`, not a `BandedMatrix{<:, Matrix}`.

Following how it works for arrays, `(A + B).data` will be similar to `B.data` (though always a banded matrix, I think).

This means introducing a `similar_banded` that works like `similar`, but always creates a banded matrix.
And in order to create `similar_banded`, it's simpler to make sure `bandwidth` works on all types, including sub-arrays, which might lead to some refactoring.