### PR TITLE
Examples in README and documentation #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ brand(m,n,l,u)     # creates a random banded matrix, with l sub-diagonals and u 
 BandedMatrix(Ones(m,n), (l,u))     # creates a banded matrix of ones, with l sub-diagonals and u super-diagonals
 BandedMatrix(Eye(n), (l,u))        # creates a banded  n x n identity matrix, with l sub-diagonals and u super-diagonals
 BandedMatrix(-1=> 1:5, 2=>1:3)     # creates a 5 x 5 banded matrix version of diagm(-1=> 1:5, 2=>1:3)
-BandedMatrix((-1=> 1:5, 2=>1:3), (n,m) (l,u))     # creates an n x m banded matrix with l sub-diagonals and u super-diagonals with the specified diagonals
 ```
+For more examples, see [the documentation](http://juliamatrices.github.io/BandedMatrices.jl/latest/#Creating-banded-matrices-1).
 
 Specialized algebra routines are overriden, include `*` and `\`:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,12 +42,12 @@ julia> BandedMatrix(Ones(5,5), (1,2))
            1.0  1.0  1.0
                 1.0  1.0
 ```
-To create a banded matrix of a given size with constant bands (such as the classical finite difference approximation of the two-dimensional Laplacian on the unit square [0,1]×[0,1]), you can use the following:
+To create a banded matrix of a given size with constant bands (such as the classical finite difference approximation of the one-dimensional Laplacian on the unit interval [0,1]), you can use the following:
 ```julia
 n = 128
 h = 1/n
-A = BandedMatrix{Float64}(undef, (n*n,n*n), (1,1))
-A[band(0)] .= -4/h^2
+A = BandedMatrix{Float64}(undef, (n,n), (1,1))
+A[band(0)] .= -2/h^2
 A[band(1)] .= A[band(-1)] .= 1/h^2
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,8 +42,14 @@ julia> BandedMatrix(Ones(5,5), (1,2))
            1.0  1.0  1.0
                 1.0  1.0
 ```
-
-
+To create a banded matrix of a given size with constant bands (such as the classical finite difference approximation of the two-dimensional Laplacian on the unit square [0,1]×[0,1]), you can use the following:
+```julia
+n = 128
+h = 1/n
+A = BandedMatrix{Float64}(undef, (n*n,n*n), (1,1))
+A[band(0)] .= -4/h^2
+A[band(1)] .= A[band(-1)] .= 1/h^2
+```
 
 ## Accessing banded matrices
 


### PR DESCRIPTION
This PR removes the obsolete (no longer working) example from the README and adds a link to the documentation, where the finite-difference example from #65 is added.