### PR TITLE
Cholesky improvements

### DIFF
--- a/src/symbanded/BandedCholesky.jl
+++ b/src/symbanded/BandedCholesky.jl
@@ -14,12 +14,12 @@ convert(::Type{BandedCholesky{T}}, B::BandedCholesky{S}) where {T<:Number, S<:Nu
 @inline bandwidth(A::BandedCholesky, k) = bandwidth(A.data, k)
 
 # Cholesky factorisation.
-function cholesky!(A::Symmetric{T,<:BandedMatrix}) where {T<:Number}
+function cholesky!(A::Union{Symmetric{R,<:BandedMatrix},Hermitian{Complex{R},<:BandedMatrix}}) where {R<:Real}
     P = parent(A)
     pbtrf!('U', size(A, 1), bandwidth(A), bandeddata(parent(P)))
-    BandedCholesky{T}(P)
+    BandedCholesky{eltype(A)}(P)
 end
-cholesky(A::Symmetric{<:Any, <:BandedMatrix}) = cholesky!(copy(A))
+cholesky(A::Union{Symmetric{R,<:BandedMatrix},Hermitian{Complex{R},<:BandedMatrix}}) where {R<:Real} = cholesky!(copy(A))
 cholesky(F::BandedCholesky) = F # no op
 
 function getindex(F::BandedCholesky, d::Symbol)

--- a/src/symbanded/BandedCholesky.jl
+++ b/src/symbanded/BandedCholesky.jl
@@ -28,6 +28,12 @@ function getindex(F::BandedCholesky, d::Symbol)
     throw(KeyError(d))
 end
 
+function ldiv!(A::BandedCholesky{T}, B::AbstractVecOrMat{T}) where T
+    checksquare(A)
+    m = size(A,1)
+    pbtrs!('U', size(A, 1), bandwidth(A,2), A.data.data, B)
+end
+
 ## Utilities
 
 # check if matrix is square before solution of linear system or before converting

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -122,4 +122,10 @@ end
     A = Symmetric(BandedMatrix(0 => 1 ./ [12, 6, 6, 6, 12],
                                1 => ones(4) ./ 24))
     @test norm(cholesky(A).data - cholesky(Matrix(A)).U) < 1e-15
+
+    Ac = cholesky(A)
+    b = rand(size(A,1))
+    @test norm(Ac\b - Matrix(A)\b) < 1e-14
+
+    @test_throws DimensionMismatch Ac\rand(size(A,1)+1)
 end

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -117,3 +117,9 @@ end
     @test all(A*x .=== (similar(x) .= Mul(A,x)) .=== (similar(x) .= one(T).*Mul(A,x) .+ zero(T).*similar(x)) .===
                 BLAS.hbmv!('L', 1, one(T), view(parent(A).data,3:4,:), x, zero(T), similar(x)))
 end
+
+@testset "Cholesky" begin
+    A = Symmetric(BandedMatrix(0 => 1 ./ [12, 6, 6, 6, 12],
+                               1 => ones(4) ./ 24))
+    @test norm(cholesky(A).data - cholesky(Matrix(A)).U) < 1e-15
+end


### PR DESCRIPTION
Prior to this PR, this is what I get:

```julia
julia> cholesky(B)
ERROR: MethodError: LinearAlgebra.cholesky!(::Symmetric{Float64,BandedMatrices.BandedMatrix{Float64,Array{Float64,2}}}) is ambiguous. Candidates:
  cholesky!(A::Symmetric{T,#s100} where #s100<:BandedMatrices.BandedMatrix) where T<:Number in BandedMatrices at /Users/jagot/.julia/packages/BandedMatrices/2idIC/src/symbanded/BandedCholesky.jl:18
  cholesky!(A::Union{Hermitian{T,S}, Hermitian{Complex{T},S}, Symmetric{T,S}} where S where T<:Real) in LinearAlgebra at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v1.0/LinearAlgebra/src/cholesky.jl:152
Possible fix, define
  cholesky!(::Symmetric{T<:Real,S} where S<:BandedMatrices.BandedMatrix)
Stacktrace:
 [1] cholesky(::Symmetric{Float64,BandedMatrices.BandedMatrix{Float64,Array{Float64,2}}}) at /Users/jagot/.julia/packages/BandedMatrices/2idIC/src/symbanded/BandedCholesky.jl:22
 [2] top-level scope at none:0
```

I have also implemented
```julia
cholesky(A)\b
```