### PR TITLE
Feat ldlt

### DIFF
--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -7,8 +7,8 @@ import LinearAlgebra: BlasInt, BlasReal, BlasFloat, BlasComplex, axpy!,
 import LinearAlgebra.BLAS: libblas
 import LinearAlgebra.LAPACK: liblapack, chkuplo, chktrans
 import LinearAlgebra: cholesky, cholesky!, norm, diag, eigvals!, eigvals, eigen!, eigen,
-            qr, axpy!, ldiv!, mul!, lu, lu!, AbstractTriangular, has_offset_axes,
-            chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle
+            qr, axpy!, ldiv!, mul!, lu, lu!, ldlt, AbstractTriangular, has_offset_axes,
+            chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, logabsdet
 import SparseArrays: sparse
 
 import Base: getindex, setindex!, *, +, -, ==, <, <=, >,
@@ -74,6 +74,7 @@ include("banded/gbmm.jl")
 include("banded/linalg.jl")
 
 include("symbanded/symbanded.jl")
+include("symbanded/ldlt.jl")
 include("symbanded/BandedCholesky.jl")
 
 include("tribanded.jl")

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -7,7 +7,7 @@ import LinearAlgebra: BlasInt, BlasReal, BlasFloat, BlasComplex, axpy!,
 import LinearAlgebra.BLAS: libblas
 import LinearAlgebra.LAPACK: liblapack, chkuplo, chktrans
 import LinearAlgebra: cholesky, cholesky!, norm, diag, eigvals!, eigvals, eigen!, eigen,
-            qr, axpy!, ldiv!, mul!, lu, lu!, ldlt, AbstractTriangular, has_offset_axes,
+            qr, axpy!, ldiv!, mul!, lu, lu!, ldlt, ldlt!, AbstractTriangular, has_offset_axes,
             chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, logabsdet
 import SparseArrays: sparse
 

--- a/src/symbanded/ldlt.jl
+++ b/src/symbanded/ldlt.jl
@@ -7,7 +7,7 @@ factorize(S::Symmetric{<:Any,<:BandedMatrix}) = ldlt(S)
 function ldlt!(F::Symmetric{T,M}) where {T<:Real,M<:BandedMatrix{T}}
     A = F.data
     n = size(A, 1)
-    b = bandwidth(A, 1)
+    b = bandwidth(F)
     if F.uplo == 'L'
         @inbounds for j = 1:n
             @simd for k = max(1,j-b-1):j-1
@@ -38,7 +38,8 @@ end
 
 function ldlt(A::Symmetric{T,M}) where {T<:Real,M<:BandedMatrix{T}}
     S = typeof(zero(T)/one(T))
-    return S == T ? ldlt!(copy(A)) : ldlt!(Symmetric(BandedMatrix{S}(M), A.uplo))
+    uplo = A.uplo == 'U' ? :U : :L
+    return S == T ? ldlt!(copy(A)) : ldlt!(Symmetric(BandedMatrix{S}(A), uplo))
 end
 
 

--- a/src/symbanded/ldlt.jl
+++ b/src/symbanded/ldlt.jl
@@ -1,0 +1,57 @@
+## Banded LDLᵀ decomposition
+
+@inline bandwidth(A::LDLt{T,Symmetric{T,M}}, k) where {T,M<:BandedMatrix{T}} = bandwidth(A.data, k)
+
+factorize(S::Symmetric{<:Any,<:BandedMatrix}) = ldlt(S)
+
+function ldlt(A::Symmetric{T,M}) where {T<:Real,M<:BandedMatrix{T}}
+    F = Symmetric(similar(A.data), :L)
+    B = F.data
+    n = size(A, 1)
+    b = bandwidth(A, 1)
+    for j = 1:n
+        B[j,j] = A[j,j]
+        for k = max(1,j-b-1):j-1
+            B[j,j] -= B[j,k]^2*B[k,k]
+        end
+        for i = j+1:min(n,j+b)
+            B[i,j] = A[i,j]
+            for k = max(1,j-b-1):j-1
+                B[i,j] -= B[i,k]*B[j,k]*B[k,k]
+            end
+            B[i,j] /= B[j,j]
+        end
+    end
+    return LDLt{T,Symmetric{T,M}}(F)
+end
+
+function ldiv!(S::LDLt{T,Symmetric{T,M}}, B::AbstractVecOrMat{T}) where {T,M<:BandedMatrix{T}}
+    @assert !has_offset_axes(B)
+    n, nrhs = size(B, 1), size(B, 2)
+    if size(S, 1) != n
+        throw(DimensionMismatch("Matrix has dimensions $(size(S)) but right hand side has first dimension $n"))
+    end
+    A = S.data
+    b = bandwidth(A, 1)
+    @inbounds for l = 1:nrhs
+        for j = 1:n
+            @simd for k = max(1,j-b-1):j-1
+                B[j,l] -= A[j,k]*B[k,l]
+            end
+        end
+        @simd for j = 1:n
+            B[j,l] /= A[j,j]
+        end
+        for j = n:-1:1
+            @simd for k = j+1:min(n,j+b)
+                B[j,l] -= A[k,j]*B[k,l]
+            end
+        end
+    end
+    B
+end
+
+function logabsdet(F::LDLt{T,Symmetric{T,M}}) where {T,M<:BandedMatrix{T}}
+    it = (F.data[i,i] for i in 1:size(F, 1))
+    return sum(log∘abs, it), prod(sign, it)
+end

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -120,7 +120,7 @@ end
 end
 
 @testset "LDLᵀ" begin
-    for T in subtypes(AbstractFloat)
+    for T in (Float16, Float32, Float64, BigFloat)
         A = BandedMatrix{T}(undef,(10,10),(2,2))
         A[band(0)] .= 4
         A[band(1)] .= -one(T)/4

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -51,7 +51,7 @@ using BandedMatrices, LinearAlgebra, LazyArrays, Random, Test
     end
 
     function Bn(::Type{T}, N::Int) where {T}
-        B = Symmetric(BandedMatrix(Zeros{T}(N,N), (0,2)))
+        B = Symmetric(BandedMatrix(Zeros{T}(N,N), (0, 2)))
         for n = 0:N-1
             parent(B).data[3,n+1] = T(2*(n+1)*(n+2))/T((2n+1)*(2n+5))
         end
@@ -120,8 +120,8 @@ end
 end
 
 @testset "LDLᵀ" begin
-    for T in (Float16, Float32, Float64, BigFloat)
-        A = BandedMatrix{T}(undef,(10,10),(2,2))
+    for T in (Float16, Float32, Float64, BigFloat, Rational{BigInt})
+        A = BandedMatrix{T}(undef,(10,10),(0,2))
         A[band(0)] .= 4
         A[band(1)] .= -one(T)/4
         A[band(2)] .= -one(T)/16
@@ -131,6 +131,8 @@ end
         x = Matrix(SAU)\b
         y = F\b
         @test x ≈ y
+        A = BandedMatrix{T}(undef,(10,10),(2,0))
+        A[band(0)] .= 4
         A[band(-1)] .= -one(T)/3
         A[band(-2)] .= -one(T)/9
         SAL = Symmetric(A, :L)
@@ -140,6 +142,13 @@ end
         @test x ≈ y
         @test_throws DimensionMismatch F\[b;b]
         @test det(F) ≈ det(SAL)
+    end
+    for T in (Int16, Int32, Int64, BigInt)
+        A = BandedMatrix{T}(undef, (4,4), (1,1))
+        A[band(0)] .= 3
+        A[band(1)] .= 1
+        F = ldlt(Symmetric(A))
+        @test eltype(F) == float(T)
     end
 end
 


### PR DESCRIPTION
This extends `LinearAlgebra`'s LDL<sup>T</sup> for the symmetric tridiagonal type to symmetric banded matrices.

I think it's good to have a linear system solver written in plain Julia because currently `lu` and `cholesky` pipe directly into LAPACK and `qr` uses some BLAS functions.

There's no pivoting (there's no pivoting for `SymTridiagonal` either) but unlike Cholesky it may not fail just because the matrix is indefinite.