### PR TITLE
add LAPACK eigen methods

### DIFF
--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -8,7 +8,8 @@ import LinearAlgebra.BLAS: libblas
 import LinearAlgebra.LAPACK: liblapack, chkuplo, chktrans
 import LinearAlgebra: cholesky, cholesky!, norm, diag, eigvals!, eigvals, eigen!, eigen,
             qr, axpy!, ldiv!, mul!, lu, lu!, ldlt, ldlt!, AbstractTriangular, has_offset_axes,
-            chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, logabsdet
+            chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, logabsdet,
+            svdvals, svdvals!
 import SparseArrays: sparse
 
 import Base: getindex, setindex!, *, +, -, ==, <, <=, >,

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -387,4 +387,11 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
         @test bandwidths(real(B)) == bandwidths(imag(B)) == bandwidths(B)
         @test real(B) + im*imag(B) == B
     end
+
+    @testset "induced norm" begin
+        A = brand(Float64, 12, 10, 2, 3)
+        B = Matrix(A)
+	    @test opnorm(A) ≈ opnorm(B)
+	    @test cond(A) ≈ cond(B)
+    end
 end


### PR DESCRIPTION
Actually, the result of #77 returned eigenvectors of symmetric banded matrices as those of the similar `SymTridiagonal` matrices.

In the long run, I feel it would be best to return an eigen-struct uncoupling the band reduction step from the symmetric tridiagonal step. But in the short run, there's no good reason not to override the LAPACK drivers. 