### PR TITLE
refactor cholesky, support general types

### DIFF
--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -3,10 +3,11 @@ using Base, FillArrays, LazyArrays, MatrixFactorizations, LinearAlgebra, SparseA
 using LinearAlgebra.LAPACK
 import Base: axes, axes1, getproperty, iterate, tail
 import LinearAlgebra: BlasInt, BlasReal, BlasFloat, BlasComplex, axpy!,
-                        copy_oftype, checksquare, adjoint, transpose, AdjOrTrans, HermOrSym
+                        copy_oftype, checksquare, adjoint, transpose, AdjOrTrans, HermOrSym,
+                        _chol!
 import LinearAlgebra.BLAS: libblas
 import LinearAlgebra.LAPACK: liblapack, chkuplo, chktrans
-import LinearAlgebra: cholesky, cholesky!, norm, diag, eigvals!, eigvals, eigen!, eigen,
+import LinearAlgebra: cholesky, cholesky!, cholcopy, norm, diag, eigvals!, eigvals, eigen!, eigen,
             qr, qr!, axpy!, ldiv!, mul!, lu, lu!, ldlt, ldlt!, AbstractTriangular, has_offset_axes,
             chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, logabsdet,
             svdvals, svdvals!, QRPackedQ

--- a/src/symbanded/BandedCholesky.jl
+++ b/src/symbanded/BandedCholesky.jl
@@ -63,8 +63,14 @@ banded_chol!(A, ::Type{T}) where T = banded_chol!(MemoryLayout(A), A, T)
 chol!(A::AbstractBandedMatrix, ::Type{UpperTriangular}) = banded_chol!(A, UpperTriangular)
 chol!(A::AbstractBandedMatrix, ::Type{LowerTriangular}) = banded_chol!(A, LowerTriangular)
 
-_ldiv!(::BandedColumns{DenseColumnMajor}, A::Cholesky{T}, B::AbstractVecOrMat{T}) where T<:BlasFloat =
-    pbtrs!('U', size(A, 1), bandwidth(A.factors,2), A.factors.data, B)
+function _ldiv!(::BandedColumns{DenseColumnMajor}, A::Cholesky{T}, B::AbstractVecOrMat{T}) where T<:BlasFloat
+    if A.uplo == 'U'
+        pbtrs!('U', size(A, 1), bandwidth(A.factors,2), bandeddata(A.factors), B)
+    else
+        pbtrs!('L', size(A, 1), bandwidth(A.factors,1), bandeddata(A.factors), B)
+    end
+    B
+end
 
 function _ldiv!(::AbstractBandedLayout, C::Cholesky, B::AbstractMatrix)
     if C.uplo == 'L'

--- a/src/symbanded/BandedCholesky.jl
+++ b/src/symbanded/BandedCholesky.jl
@@ -1,53 +1,84 @@
-## Banded Cholesky decomposition
 
-struct BandedCholesky{T} <: Factorization{T}
-    data::BandedMatrix{T}  # symmetric banded matrix
+function banded_chol!(::BandedColumns{DenseColumnMajor}, 
+                       A::AbstractMatrix{T}, ::Type{UpperTriangular}) where T<:BlasFloat
+    C, info = pbtrf!('U', size(A, 1), bandwidth(A,2), bandeddata(A))
+    UpperTriangular(C), info
 end
 
-# conversion
-convert(::Type{BandedCholesky{T}}, B::BandedCholesky{S}) where {T<:Number, S<:Number} =
-    BandedCholesky{T}(convert(BandedMatrix{T}, B.data))
-
-# size of the parent array
-@inline size(A::BandedCholesky) = size(A.data)
-@inline size(A::BandedCholesky, k::Integer) = size(A.data, k)
-@inline bandwidth(A::BandedCholesky, k) = bandwidth(A.data, k)
-
-# Cholesky factorisation.
-function cholesky!(A::Union{Symmetric{R,<:BandedMatrix},Hermitian{Complex{R},<:BandedMatrix}}) where {R<:Real}
-    P = parent(A)
-    pbtrf!('U', size(A, 1), bandwidth(A), bandeddata(parent(P)))
-    BandedCholesky{eltype(A)}(P)
-end
-cholesky(A::Union{Symmetric{R,<:BandedMatrix},Hermitian{Complex{R},<:BandedMatrix}}) where {R<:Real} = cholesky!(copy(A))
-cholesky(F::BandedCholesky) = F # no op
-
-function getindex(F::BandedCholesky, d::Symbol)
-    d == :U && return F.data # UpperTriangular(F.data)
-    d == :L && return F.data' # LowerTriangular(F.data)
-    throw(KeyError(d))
-end
-
-function ldiv!(A::BandedCholesky{T}, B::AbstractVecOrMat{T}) where T
-    checksquare(A)
-    m = size(A,1)
-    pbtrs!('U', size(A, 1), bandwidth(A,2), A.data.data, B)
-end
-
-## Utilities
-
-# check if matrix is square before solution of linear system or before converting
-checksquare(A::BandedCholesky) = checksquare(A.data)
-
-
-## Conversion/Promotion
-
-# Converts A and b to the narrowest blas type
-for typ in [BandedCholesky]
-    @eval function _convert_to_blas_type(A::$typ, B::AbstractVecOrMat{T}) where {T<:Number}
-        TS = _promote_to_blas_type(eltype(A), eltype(B))
-        AA = convert($typ{TS}, A)
-        BB = convert(Array{TS, ndims(B)}, B)
-        AA, BB # one of these two might make a copy
+## Non BLAS/LAPACK element types (generic)
+function banded_chol!(_, A::AbstractMatrix, ::Type{UpperTriangular})
+    @assert !has_offset_axes(A)
+    n = checksquare(A)
+    u = bandwidth(A,2)
+    @inbounds begin
+        for k = 1:n
+            for i = max(1,k-u):k - 1
+                A[k,k] -= A[i,k]'A[i,k]
+            end
+            Akk, info = _chol!(A[k,k], UpperTriangular)
+            if info != 0
+                return UpperTriangular(A), info
+            end
+            A[k,k] = Akk
+            AkkInv = inv(copy(Akk'))
+            for j = k + 1:min(k+u,n)
+                for i = max(1,j-u):k - 1
+                    A[k,j] -= A[i,k]'A[i,j]
+                end
+                A[k,j] = AkkInv*A[k,j]
+            end
+        end
     end
+    return UpperTriangular(A), convert(BlasInt, 0)
 end
+function banded_chol!(_, A::AbstractMatrix, ::Type{LowerTriangular})
+    @assert !has_offset_axes(A)
+    n = checksquare(A)
+    l = bandwidth(A,1)
+    @inbounds begin
+        for k = 1:n
+            for i = max(1,k-l):k - 1
+                A[k,k] -= A[k,i]*A[k,i]'
+            end
+            Akk, info = _chol!(A[k,k], LowerTriangular)
+            if info != 0
+                return LowerTriangular(A), info
+            end
+            A[k,k] = Akk
+            AkkInv = inv(Akk)
+            for j = max(1,k-l):k - 1
+                @simd for i = k + 1:min(n,j+l)
+                    A[i,k] -= A[i,j]*A[k,j]'
+                end
+            end
+            for i = k + 1:min(n,k+l)
+                A[i,k] *= AkkInv'
+            end
+        end
+     end
+    return LowerTriangular(A), convert(BlasInt, 0)
+end
+
+banded_chol!(A, ::Type{T}) where T = banded_chol!(MemoryLayout(A), A, T)
+chol!(A::AbstractBandedMatrix, ::Type{UpperTriangular}) = banded_chol!(A, UpperTriangular)
+chol!(A::AbstractBandedMatrix, ::Type{LowerTriangular}) = banded_chol!(A, LowerTriangular)
+
+_ldiv!(::BandedColumns{DenseColumnMajor}, A::Cholesky{T}, B::AbstractVecOrMat{T}) where T<:BlasFloat =
+    pbtrs!('U', size(A, 1), bandwidth(A.factors,2), A.factors.data, B)
+
+function _ldiv!(::AbstractBandedLayout, C::Cholesky, B::AbstractMatrix)
+    if C.uplo == 'L'
+        return ldiv!(adjoint(LowerTriangular(C.factors)), ldiv!(LowerTriangular(C.factors), B))
+    else
+        return ldiv!(UpperTriangular(C.factors), ldiv!(adjoint(UpperTriangular(C.factors)), B))
+    end
+end    
+
+ldiv!(A::Cholesky{T,<:AbstractBandedMatrix}, B::StridedVecOrMat{T}) where T<:BlasFloat = 
+    _ldiv!(MemoryLayout(A.factors), A, B)
+
+# @lazyldiv Cholesky{<:Any,<:AbstractBandedMatrix}
+
+# For some bizarre reason this isnt in LinearAlgebra
+cholesky(A::Symmetric{T,<:BandedMatrix{T}},
+    ::Val{false}=Val(false); check::Bool = true) where T<:Real = cholesky!(cholcopy(A); check = check)

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -150,13 +150,15 @@ end
 
 
 @testset "Cholesky" begin
-    A = Symmetric(BandedMatrix(0 => 1 ./ [12, 6, 6, 6, 12],
-                               1 => ones(4) ./ 24))
-    @test norm(cholesky(A).data - cholesky(Matrix(A)).U) < 1e-15
+    for T in (Float64, BigFloat) 
+        A = Symmetric(BandedMatrix(0 => one(T) ./ [12, 6, 6, 6, 12],
+                                1 => ones(T,4) ./ 24))
+        Ac = cholesky(A)
 
-    Ac = cholesky(A)
-    b = rand(size(A,1))
-    @test norm(Ac\b - Matrix(A)\b) < 1e-14
+        @test Ac isa Cholesky{T,<:BandedMatrix{T}}                           
+        @test norm(Ac.U - cholesky(Matrix(A)).U) < 1e-15
 
-    @test_throws DimensionMismatch Ac\rand(size(A,1)+1)
+        b = rand(T,size(A,1))
+        @test norm(Ac\b - Matrix(A)\b) < 1e-14
+    end                    
 end

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -156,9 +156,23 @@ end
         Ac = cholesky(A)
 
         @test Ac isa Cholesky{T,<:BandedMatrix{T}}                           
-        @test norm(Ac.U - cholesky(Matrix(A)).U) < 1e-15
+        @test Ac.U ≈ cholesky(Matrix(A)).U
 
         b = rand(T,size(A,1))
-        @test norm(Ac\b - Matrix(A)\b) < 1e-14
-    end                    
+        @test Ac\b ≈ Matrix(A)\b
+        @test_broken Ac\b ≈ A\b
+    end 
+    
+    for T in (Float64, BigFloat) 
+        A = Symmetric(BandedMatrix(0 => one(T) ./ [12, 6, 6, 6, 12],
+                                -1 => ones(T,4) ./ 24), :L)
+        Ac = cholesky(A)
+
+        @test Ac isa Cholesky{T,<:BandedMatrix{T}}                           
+        @test Ac.L ≈ cholesky(Matrix(A)).L
+
+        b = rand(T,size(A,1))
+        @test Ac\b ≈ Matrix(A)\b
+        @test_broken Ac\b ≈ A\b
+    end 
 end


### PR DESCRIPTION
@MikaelSlevinsky Any comments? This uses LinearAlgebra.Cholesky for much cleaner code, and made it easy to generalise.

