### PR TITLE
Define cholesky for Hermitian matrices

### DIFF
--- a/src/symbanded/BandedCholesky.jl
+++ b/src/symbanded/BandedCholesky.jl
@@ -95,3 +95,6 @@ ldiv!(A::Cholesky{T,<:AbstractBandedMatrix}, B::StridedVecOrMat{T}) where T<:Bla
 # For some bizarre reason this isnt in LinearAlgebra
 cholesky(A::Symmetric{T,<:BandedMatrix{T}},
     ::Val{false}=Val(false); check::Bool = true) where T<:Real = cholesky!(cholcopy(A); check = check)
+
+cholesky(A::Hermitian{T,<:BandedMatrix{T}},
+    ::Val{false}=Val(false); check::Bool = true) where T = cholesky!(cholcopy(A); check = check)

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -184,4 +184,17 @@ end
         @test Ac\b ≈ Matrix(A)\b
         @test_broken Ac\b ≈ A\b
     end
+
+    let T = ComplexF64
+        A = Hermitian(BandedMatrix(0 => one(T) ./ [12, 6, 6, 6, 12],
+                                   1 => ones(T,4) ./ 24))
+        Ac = cholesky(A)
+
+        @test Ac isa Cholesky{T,<:BandedMatrix{T}}
+        @test Ac.U ≈ cholesky(Matrix(A)).U
+
+        b = rand(T,size(A,1))
+        @test Ac\b ≈ Matrix(A)\b
+        @test_broken Ac\b ≈ A\b
+    end
 end


### PR DESCRIPTION
This small PR adds a definition of `cholesky` for Hermitian matrices, similar to the existent definition for `Symmetric` matrices.