### PR TITLE
Added tridiagonalization for symmetric/Hermitian banded matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.15.12"
+version = "0.15.13"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ julia = "1"
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 
 [targets]
-test = ["Base64", "Test"]
+test = ["Base64", "Test", "GenericLinearAlgebra"]

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -92,10 +92,12 @@ include("symbanded/ldlt.jl")
 include("symbanded/BandedCholesky.jl")
 include("symbanded/SplitCholesky.jl")
 include("symbanded/bandedeigen.jl")
+include("symbanded/tridiagonalize.jl")
 
 include("tribanded.jl")
 
 include("interfaceimpl.jl")
+
 
 # function _precompile_()
 #     precompile(Tuple{typeof(gbmm!), Char, Char, Float64, BandedMatrix{Float64,Array{Float64,2},Base.OneTo{Int64}}, BandedMatrix{Float64,Array{Float64,2},Base.OneTo{Int64}}, Float64, BandedMatrix{Float64,Array{Float64,2},Base.OneTo{Int64}}})

--- a/src/symbanded/symbanded.jl
+++ b/src/symbanded/symbanded.jl
@@ -116,11 +116,13 @@ function _tridiagonalize!(A::AbstractMatrix{T}, ::SymmetricLayout{<:BandedColumn
 end
 
 tridiagonalize!(A::AbstractMatrix) = _tridiagonalize!(A, MemoryLayout(typeof(A)))
-tridiagonalize(A::AbstractMatrix) = tridiagonalize!(copy(A))
+
+eigvals(A::Symmetric{T,<:BandedMatrix{T}}) where T<:Base.IEEEFloat = eigvals!(copy(A))
+eigvals(A::Symmetric{T,<:BandedMatrix{T}}) where T<:Real = eigvals!(tridiagonalize(A))
+eigvals(A::Hermitian{T,<:BandedMatrix{T}}) where T<:Real = eigvals!(tridiagonalize(A))
+eigvals(A::Hermitian{T,<:BandedMatrix{T}}) where T<:Complex = eigvals!(tridiagonalize(A))
 
 eigvals!(A::Symmetric{T,<:BandedMatrix{T}}) where T <: Real = eigvals!(tridiagonalize!(A))
-eigvals(A::Symmetric{T,<:BandedMatrix{T}}) where T <: Real = eigvals!(copy(A))
-
 function eigvals!(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix{T}}) where T<:Real
     n = size(A, 1)
     @assert n == size(B, 1)

--- a/src/symbanded/tridiagonalize.jl
+++ b/src/symbanded/tridiagonalize.jl
@@ -23,94 +23,14 @@ function tridiagonalize(A::Union{Symmetric{<:Real},Hermitian}, d::Integer=0)
     B = copybands(A, d)
     td = _tridiag_algorithm!(B)
     dv = [real(B[1,i]) for i in 1:n]
-    ev = d > 1 ? [abs(B[2,i]) for i = 2:n] : zeros(real(eltype(A)), n-1)
-    SymTridiagonal(dv, ev)
-end
-
-# B[1:q,1:n] has the bands of a (2q-1)-banded hermitian nxn-matrix.
-# superdiagonal i valid in B[i,i+1:n]. B is completely overwritten.
-# The result is in B[1:2,1:n]
-function _tridiag_algorithm!(B)
-    d, n = size(B)
-    0 < d <= n || throw(ArgumentError("number of diagonals $d not in 1:$n"))
-
-    @inbounds for bm = d-1:-1:2
-        for k = 1:n-bm
-            kp = k 
-            apiv = B[bm+1,bm+kp] 
-            iszero(apiv) && continue
-            for i = bm+k-1:bm:n-1
-                b = B[ i-kp+1,i]
-                c, s, r, α = givens2(b, apiv)
-                u, v = B[1,i], B[1,i+1]
-                upx = (u + v) / 2
-                B[1,i] = (u - v) / 2
-                B[i-kp+1,i] = r
-                for j = kp+1:i
-                    u = B[i-j+1,i]
-                    v = B[i-j+2,i+1] * α'
-                    B[i-j+1,i], B[i-j+2,i+1] = u * c + v * s, -u * s + v * c
-                end
-                B[1,i+1] = -(B[1,i] * α)'
-                ip = i + bm
-                for j = i+1:min(ip, n)
-                    u = B[j-i+1,j]
-                    v = B[j-i,j] * α
-                    B[j-i+1,j], B[j-i,j] = u * c + v * s, -u * s + v * c
-                end
-                w = real(B[1,i+1])
-                B[1,i] = upx - w
-                B[1,i+1] = upx + w
-                if ip < n
-                    v = B[ip-i+1,ip+1] * α
-                    apiv, B[ip-i+1,ip+1] = v * s, v * c
-                end
-                kp = i
-            end
-        end
-    end
-    B
-end
-
-function givens2(a::T, b::T) where T <: AbstractFloat
-    r = _hypot(a, b)
-    s = b / r
-    c = a / r
-    c, s, r, one(T)
-end
-@inline function givens2(a::T, b::T) where T <: Complex
-    aa = _abs(a)
-    ba = _abs(b)
-    ra = _hypot(aa, ba)
-    s = ba / ra
-    c = aa / ra
-    ua = a / aa
-    α = ua' * (b / ba)
-    r = ua * ra
-    c, s, r, α
-end
-
-function tridiagonalizeGA(A::Union{Symmetric{<:Real},Hermitian}, d::Integer=0)
-    m, n = size(A)
-    m == n || throw(DimensionMismatch("matrix is not square: dimensions are $((m, n))"))
-    dmax = bandwidth(A) + 1
-    if d == 0
-        d = min(n, dmax)
-    end
-
-    0 < d <= dmax || throw(ArgumentError("number of diagonals $d not in 1:$dmax"))
-
-    B = copybands(A, d)
-    td = _tridiag_algorithmGA!(B)
-    dv = [real(B[1,i]) for i in 1:n]
-    ev = d > 1 ? [abs(B[2,i]) for i = 2:n] : zeros(real(eltype(A)), n-1)
+    ev = d > 1 ? [-abs(B[2,i]) for i = 2:n] : zeros(real(eltype(A)), n-1)
     SymTridiagonal(dv, ev)
 end
 
 # B[1:q,1:n] has the bands of a (2q-1)-banded hermitian nxn-matrix.
 # superdiagonal i valid in B[i,i+1:n]. B is completely overwritten.
 # The result is in B[1:2,1:nvens2]
-function _tridiag_algorithmGA!(B)
+function _tridiag_algorithm!(B)
     d, n = size(B)
     0 < d <= n || throw(ArgumentError("number of diagonals $d not in 1:$n"))
 
@@ -150,20 +70,6 @@ function _tridiag_algorithmGA!(B)
         end
     end
     B
-end
-
-# speedy version of `abs(::Complex)` - avoid use of `hypot`. 
-_abs(x::Complex) = _hypot(real(x), imag(x))
-_abs(x) = abs(x)
-
-# this version has 1 bit less accuracy and runs 5-10 times faster than `hypot`.
-function _hypot(x, y)
-    s = sqrt(abs2(x) + abs2(y))
-    _isclean(s) ? s : hypot(x, y)
-end
-
-function _isclean(a::T) where T<:AbstractFloat
-    isfinite(a) && a >= sqrt(2 * floatmin(T))
 end
 
 # generalization of method for symmetric BandedMatrices

--- a/src/symbanded/tridiagonalize.jl
+++ b/src/symbanded/tridiagonalize.jl
@@ -73,7 +73,7 @@ function _tridiag_algorithm!(B)
 end
 
 # generalization of method for symmetric BandedMatrices
-bandwidth(A::Matrix) = min(size(A)...) - 1
+bandwidth(A::AbstractMatrix) = min(size(A)...) - 1
 
 function copybands(A::AbstractMatrix{T}, d::Integer) where T
     n = min(size(A)...)

--- a/src/symbanded/tridiagonalize.jl
+++ b/src/symbanded/tridiagonalize.jl
@@ -1,7 +1,3 @@
-
-export tridiagonalize
-using LinearAlgebra
-
 """
     tridiagonalize(A, d::Integer=0)
 

--- a/src/symbanded/tridiagonalize.jl
+++ b/src/symbanded/tridiagonalize.jl
@@ -1,0 +1,122 @@
+
+export tridiagonalize
+using LinearAlgebra
+
+"""
+    tridiagonalize(A, d::Integer=0)
+
+The symmetric real or Hermitian input matrix `A` is transformed to a real
+`SymTridiagonal` matrix.
+For general matrices only `d` superdiagonals are processed.
+Works efficiently for `BandedMatrices`.
+"""
+function tridiagonalize(A::Union{Symmetric{<:Real},Hermitian}, d::Integer=0)
+    m, n = size(A)
+    m == n || throw(DimensionMismatch("matrix is not square: dimensions are $((m, n))"))
+    dmax = bandwidth(A) + 1
+    if d == 0
+        d = min(n, dmax)
+    end
+
+    0 < d <= dmax || throw(ArgumentError("number of diagonals $d not in 1:$dmax"))
+
+    B = copybands(A, d)
+    td = _tridiag_algorithm!(B)
+    dv = [real(B[1,i]) for i in 1:n]
+    ev = d > 1 ? [abs(B[2,i]) for i = 2:n] : zeros(real(eltype(A)), n-1)
+    SymTridiagonal(dv, ev)
+end
+
+# B[1:q,1:n] has the bands of a (2q-1)-banded hermitian nxn-matrix.
+# superdiagonal i valid in B[i,i+1:n]. B is completely overwritten.
+# The result is in B[1:2,1:n]
+function _tridiag_algorithm!(B)
+    d, n = size(B)
+    0 < d <= n || throw(ArgumentError("number of diagonals $d not in 1:$n"))
+
+    @inbounds for bm = d-1:-1:2
+        for k = 1:n-bm
+            kp = k 
+            apiv = B[bm+1,bm+kp] 
+            iszero(apiv) && continue
+            for i = bm+k-1:bm:n-1
+                b = B[ i-kp+1,i]
+                c, s, r, α = givens2(b, apiv)
+                u, v = B[1,i], B[1,i+1]
+                upx = (u + v) / 2
+                B[1,i] = (u - v) / 2
+                B[i-kp+1,i] = r
+                for j = kp+1:i
+                    u = B[i-j+1,i]
+                    v = B[i-j+2,i+1] * α'
+                    B[i-j+1,i], B[i-j+2,i+1] = u * c + v * s, -u * s + v * c
+                end
+                B[1,i+1] = -(B[1,i] * α)'
+                ip = i + bm
+                for j = i+1:min(ip, n)
+                    u = B[j-i+1,j]
+                    v = B[j-i,j] * α
+                    B[j-i+1,j], B[j-i,j] = u * c + v * s, -u * s + v * c
+                end
+                w = real(B[1,i+1])
+                B[1,i] = upx - w
+                B[1,i+1] = upx + w
+                if ip < n
+                    v = B[ip-i+1,ip+1] * α
+                    apiv, B[ip-i+1,ip+1] = v * s, v * c
+                end
+                kp = i
+            end
+        end
+    end
+    B
+end
+
+function givens2(a::T, b::T) where T <: AbstractFloat
+    r = _hypot(a, b)
+    s = b / r
+    c = a / r
+    c, s, r, one(T)
+end
+@inline function givens2(a::T, b::T) where T <: Complex
+    aa = _abs(a)
+    ba = _abs(b)
+    ra = _hypot(aa, ba)
+    s = ba / ra
+    c = aa / ra
+    ua = a / aa
+    α = ua' * (b / ba)
+    r = ua * ra
+    c, s, r, α
+end
+
+# speedy version of `abs(::Complex)` - avoid use of `hypot`. 
+_abs(x::Complex) = _hypot(real(x), imag(x))
+_abs(x) = abs(x)
+
+# this version has 1 bit less accuracy and runs 5-10 times faster than `hypot`.
+function _hypot(x, y)
+    s = sqrt(abs2(x) + abs2(y))
+    _isclean(s) ? s : hypot(x, y)
+end
+
+function _isclean(a::T) where T<:AbstractFloat
+    isfinite(a) && a >= sqrt(2 * floatmin(T))
+end
+
+# generalization of method for symmetric BandedMatrices
+bandwidth(A::Matrix) = min(size(A)...) - 1
+
+function copybands(A::AbstractMatrix{T}, d::Integer) where T
+    n = min(size(A)...)
+    d = min(d, n)
+    B = Matrix{T}(undef, d, n)
+    for i = 1:d
+        B[i,1:i-1] .= zero(T)
+        for j = i:n
+            B[i,j] = A[j-i+1,j]
+        end
+    end
+    B
+end
+

--- a/src/symbanded/tridiagonalize.jl
+++ b/src/symbanded/tridiagonalize.jl
@@ -90,6 +90,68 @@ end
     c, s, r, α
 end
 
+function tridiagonalizeGA(A::Union{Symmetric{<:Real},Hermitian}, d::Integer=0)
+    m, n = size(A)
+    m == n || throw(DimensionMismatch("matrix is not square: dimensions are $((m, n))"))
+    dmax = bandwidth(A) + 1
+    if d == 0
+        d = min(n, dmax)
+    end
+
+    0 < d <= dmax || throw(ArgumentError("number of diagonals $d not in 1:$dmax"))
+
+    B = copybands(A, d)
+    td = _tridiag_algorithmGA!(B)
+    dv = [real(B[1,i]) for i in 1:n]
+    ev = d > 1 ? [abs(B[2,i]) for i = 2:n] : zeros(real(eltype(A)), n-1)
+    SymTridiagonal(dv, ev)
+end
+
+# B[1:q,1:n] has the bands of a (2q-1)-banded hermitian nxn-matrix.
+# superdiagonal i valid in B[i,i+1:n]. B is completely overwritten.
+# The result is in B[1:2,1:nvens2]
+function _tridiag_algorithmGA!(B)
+    d, n = size(B)
+    0 < d <= n || throw(ArgumentError("number of diagonals $d not in 1:$n"))
+
+    @inbounds for bm = d-1:-1:2
+        for k = 1:n-bm
+            kp = k 
+            apiv = B[bm+1,bm+kp] 
+            iszero(apiv) && continue
+            for i = bm+k-1:bm:n-1
+                b = B[ i-kp+1,i]
+                c, s, r = LinearAlgebra.givensAlgorithm(b, apiv)
+                u, v = B[1,i], B[1,i+1]
+                upx = (u + v) / 2
+                B[1,i] = (u - v) / 2
+                B[i-kp+1,i] = r
+                for j = kp+1:i
+                    u = B[i-j+1,i]
+                    v = B[i-j+2,i+1]
+                    B[i-j+1,i], B[i-j+2,i+1] = u * c + v * s, -u * s' + v * c
+                end
+                B[1,i+1] = -(B[1,i])'
+                ip = i + bm
+                for j = i+1:min(ip, n)
+                    u = B[j-i+1,j]
+                    v = B[j-i,j]
+                    B[j-i+1,j], B[j-i,j] = u * c + v * s', -u * s + v * c
+                end
+                w = real(B[1,i+1])
+                B[1,i] = upx - w
+                B[1,i+1] = upx + w
+                if ip < n
+                    v = B[ip-i+1,ip+1]
+                    apiv, B[ip-i+1,ip+1] = v * s', v * c
+                end
+                kp = i
+            end
+        end
+    end
+    B
+end
+
 # speedy version of `abs(::Complex)` - avoid use of `hypot`. 
 _abs(x::Complex) = _hypot(real(x), imag(x))
 _abs(x) = abs(x)

--- a/test/evaluations.jl
+++ b/test/evaluations.jl
@@ -1,0 +1,70 @@
+
+using BandedMatrices
+using LinearAlgebra
+
+function diffs(a, b)
+    n = length(a)
+    d = Float64.(abs.(a - b))
+    a1 = sum(d) / n
+    r1 = sum(d ./ abs.(a)) / n
+    a2 = sqrt(sum(d .* d) / n)
+    r2 = sqrt(sum(d .* d ./ abs2.(a)) / n)
+    a0 = maximum(d)
+    r0 = maximum(d ./ abs.(a))
+    a1, a2, a0, r1, r2, r0
+end
+
+function evaluate(n::Integer, T=Float64)
+
+    M = BandedMatrix(0 => 6ones(n), 1 => -4ones(n-1), 2 => 1ones(n-2));
+    MC = BandedMatrix(0 => 6ones(n), 1 => -4ones(n-1) .+ 0.1im, 2 => 1ones(n-2));
+    M = T.(M)
+    MC = Complex{T}.(MC)
+
+    println("evaluation times with 5-banded test matrixes of dimension $n")
+    println("LAPACK $T")
+    Mb = @btime BandedMatrices.tridiagonalize!((Symmetric(copy($M))));
+
+    println("generic $T")
+    Mt = @btime tridiagonalize(Hermitian($M));
+    
+    println("generic with LinearAlgebra.givensAlgorithm $T")
+    MtGA = @btime BandedMatrices.tridiagonalizeGA(Hermitian($M));
+    
+    println("generic Complex{$T}")
+    Mtc = @btime tridiagonalize(Hermitian($MC));
+
+    println("generic with LinearAlgebra.givensAlgorithm Complex{$T}")
+    MtcGA = @btime BandedMatrices.tridiagonalizeGA(Hermitian($MC));
+    
+    
+    println("generic BigFloat($(precision(BigFloat)))")
+    Mbig = @time tridiagonalize(Hermitian(big.(M)));
+    println("generic complex BigFloat($(precision(BigFloat)))")
+    MCbig = @time tridiagonalize(Hermitian(big.(MC)));
+
+    et = eigvals(Mt);
+    etGA = eigvals(MtGA);
+    etc = eigvals(Mtc);
+    etcGA = eigvals(MtcGA);
+    eb = eigvals(Mb);
+    ebib = eigvals(Mbig);
+    ebig = ebib;
+    eCbig = eigvals(MCbig);
+
+    println("absolute and relative errors")
+    println("(mean / square-mean / max ) * (abs / rel)")
+
+    println("LAPACK $T")
+    println(diffs(eb, ebig))
+    println("generic $T")
+    println(diffs(et, ebig))
+    println("generic with LinearAlgebra.givensAlgorithm $T")
+    println(diffs(etGA, ebig))
+    println("generic Complex{$T}")
+    println(diffs(etc, eCbig))
+    println("generic with LinearAlgebra.givensAlgorithm Complex{$T}")
+    println(diffs(etcGA, eCbig))
+end
+
+evaluate( 1000);

--- a/test/test_miscs.jl
+++ b/test/test_miscs.jl
@@ -50,8 +50,9 @@ import BandedMatrices: _BandedMatrix, DefaultBandedMatrix
         @test isa(AbstractMatrix{ComplexF16}(A), BandedMatrix{ComplexF16})
         @test isa(AbstractArray{ComplexF16}(A), BandedMatrix{ComplexF16})
     end
+
     @time @testset "show" begin
-      @test occursin("10×10 BandedMatrix{Float64,Array{Float64,2},"*string(Base.OneTo{Int})*"}",
+        @test occursin("10×10 BandedMatrix{Float64,$(Matrix{Float64}),"*string(Base.OneTo{Int})*"}",
          sprint() do io
             show(io, MIME"text/plain"(), brand(10, 10, 3, 3))
          end)

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -1,4 +1,4 @@
-using BandedMatrices, LinearAlgebra, ArrayLayouts, Random, Test
+using BandedMatrices, LinearAlgebra, ArrayLayouts, Random, Test, GenericLinearAlgebra
 import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedColumns
 
 @testset "Symmetric" begin
@@ -38,9 +38,18 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     # (generalized) eigen & eigvals
     Random.seed!(0)
 
-    A = Symmetric(brand(Float64, 100, 100, 2, 4))
-    @test eigvals(A) ≈ eigvals(Symmetric(Matrix(A)))
+    A = brand(Float64, 100, 100, 2, 4)
+    std = eigvals(Symmetric(Matrix(A)))
+    @test eigvals(Symmetric(A)) ≈ std
+    @test eigvals(Hermitian(A)) ≈ std
+    @test eigvals(Hermitian(big.(A))) ≈ std
+    
+    A = brand(ComplexF64, 100, 100, 4, 0)
+    std = eigvals(Hermitian(Matrix(A), :L))
+    @test eigvals(Hermitian(A, :L)) ≈ std
+    @test eigvals(Hermitian(big.(A), :L)) ≈ std
 
+    A = Symmetric(brand(Float64, 100, 100, 2, 4))
     F = eigen(A)
     Λ, Q = F
     @test Q'Matrix(A)*Q ≈ Diagonal(Λ)


### PR DESCRIPTION
Solves #179
 
A generic algorithm for tridiagonalization has been added, which extends the existing `Symmetric{IEEEFloat}` implementation to complex and big float types.

Performance and accuracy is comparable to the old implementation, which calls LAPACK functions.