### PR TITLE
Improved bandwidths(::SparseMatrixCSC) for purely upper/lower matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.15.16"
+version = "0.15.17"
 
 
 [deps]

--- a/src/generic/AbstractBandedMatrix.jl
+++ b/src/generic/AbstractBandedMatrix.jl
@@ -24,17 +24,24 @@ bandwidths(A::AbstractVecOrMat) = (size(A,1)-1 , size(A,2)-1)
 bandwidths(A::AdjOrTrans{T,S}) where {T,S} = reverse(bandwidths(parent(A)))
 
 function BandedMatrices.bandwidths(A::SparseMatrixCSC)
-    l,u = 0,0
+    l,u = -size(A,1),-size(A,2)
 
     m,n = size(A)
     rows = rowvals(A)
+    vals = nonzeros(A)
     for j = 1:n
         for ind in nzrange(A, j)
             i = rows[ind]
-            if i > j
-                l = max(l, abs(i-j))
+            # We skip non-structural zeros when computing the
+            # bandwidths.
+            iszero(vals[ind]) && continue
+            ij = abs(i-j)
+            if i ≥ j
+                l = max(l, ij)
+                u = max(u, -ij)
             elseif i < j
-                u = max(u, abs(i-j))
+                l = max(l, -ij)
+                u = max(u, ij)
             end
         end
     end

--- a/test/test_miscs.jl
+++ b/test/test_miscs.jl
@@ -49,6 +49,22 @@ import BandedMatrices: _BandedMatrix, DefaultBandedMatrix
             @test bA == A
             @test bandwidths(bA) == (l,u)
         end
+
+        for diags = [(-1 => ones(Int, 5),),
+                     (-2 => ones(Int, 5),),
+                     (2 => ones(Int, 5),),
+                     (-1 => ones(Int, 5), 1 => 2ones(Int, 5))]
+            A = BandedMatrix(diags...)
+            l,u = bandwidths(A)
+
+            sA = sparse(A)
+            @test sA isa SparseMatrixCSC
+            @test bandwidths(sA) == (l,u)
+            bA = BandedMatrix(sA)
+            @test bA isa BandedMatrix
+            @test bA == A
+            @test bandwidths(bA) == (l,u)
+        end
     end
 
     @time @testset "trivial convert routines" begin


### PR DESCRIPTION
While procrastinating, I realized I had forgotten about the following case in #189:

``` julia
julia> A = spdiagm(2 => ones(Int, 5))
7×7 SparseMatrixCSC{Int64,Int64} with 5 stored entries:
  [1, 3]  =  1
  [2, 4]  =  1
  [3, 5]  =  1
  [4, 6]  =  1
  [5, 7]  =  1

julia> BandedMatrix(A)
7×7 BandedMatrix{Int64,Array{Int64,2},Base.OneTo{Int64}}:
 ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  1  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  1  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅  1  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  1
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅
```