### PR TITLE
Specialize dot(x, A::BandedMatrix, y)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.15.22"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.15.21"
+version = "0.15.22"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -4,7 +4,7 @@ using LinearAlgebra.LAPACK
 import Base: axes, axes1, getproperty, iterate, tail
 import LinearAlgebra: BlasInt, BlasReal, BlasFloat, BlasComplex, axpy!,
                         copy_oftype, checksquare, adjoint, transpose, AdjOrTrans, HermOrSym,
-                        _chol!, rot180
+                        _chol!, rot180, dot
 import LinearAlgebra.BLAS: libblas
 import LinearAlgebra.LAPACK: liblapack, chkuplo, chktrans
 import LinearAlgebra: cholesky, cholesky!, cholcopy, norm, diag, eigvals!, eigvals, eigen!, eigen,
@@ -37,7 +37,7 @@ import ArrayLayouts: MemoryLayout, transposelayout, triangulardata,
                     reflector!, reflectorApply!, _copyto!, checkdimensions,
                     _qr!, _qr, _lu!, _lu, _factorize, AbstractTridiagonalLayout, TridiagonalLayout, BidiagonalLayout
 
-import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros
+import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros, unique_value
 
 export BandedMatrix,
        bandrange,
@@ -86,6 +86,7 @@ include("banded/BandedLU.jl")
 include("banded/bandedqr.jl")
 include("banded/gbmm.jl")
 include("banded/linalg.jl")
+include("banded/dot.jl")
 
 include("symbanded/symbanded.jl")
 include("symbanded/ldlt.jl")

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -39,6 +39,8 @@ import ArrayLayouts: MemoryLayout, transposelayout, triangulardata,
 
 import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros, unique_value
 
+using Compat # dot(x, A, y) for Julia < 1.3
+
 export BandedMatrix,
        bandrange,
        brand,

--- a/src/banded/dot.jl
+++ b/src/banded/dot.jl
@@ -1,4 +1,4 @@
-function _dot(x::AbstractVector, A::BandedMatrix, y::AbstractVector)
+function _dot(x::AbstractVector, A::AbstractBandedMatrix, y::AbstractVector)
     require_one_based_indexing(x, y)
     # This should include a message but matches LinearAlgebra.dot
     (axes(x)..., axes(y)...) == axes(A) || throw(DimensionMismatch())
@@ -21,7 +21,7 @@ function _dot(x::AbstractVector, A::BandedMatrix, y::AbstractVector)
     s
 end
 
-dot(x::AbstractVector, A::BandedMatrix, y::AbstractVector) =
+dot(x::AbstractVector, A::AbstractBandedMatrix, y::AbstractVector) =
     _dot(x, A, y)
 
 function dot(x::AbstractVector, A::BandedMatrix{<:Any,<:AbstractFill}, y::AbstractVector)

--- a/src/banded/dot.jl
+++ b/src/banded/dot.jl
@@ -1,0 +1,43 @@
+function _dot(x::AbstractVector, A::BandedMatrix, y::AbstractVector)
+    require_one_based_indexing(x, y)
+    (axes(x)..., axes(y)...) == axes(A) || throw(DimensionMismatch())
+    l,u = bandwidths(A)
+    M = size(A,1)
+    T = typeof(dot(first(x), first(A), first(y)))
+    s = zero(T)
+    i₁ = first(eachindex(x))
+    x₁ = first(x)
+    @inbounds for j in eachindex(y)
+        yj = y[j]
+        if !iszero(yj)
+            temp = zero(adjoint(A[i₁,j]) * x₁)
+            @simd for i in max(1,j-u):min(M,j+l)
+                temp += adjoint(A[i,j]) * x[i]
+            end
+            s += dot(temp, yj)
+        end
+    end
+    s
+end
+
+dot(x::AbstractVector, A::BandedMatrix, y::AbstractVector) =
+    _dot(x, A, y)
+
+function dot(x::AbstractVector, A::BandedMatrix{<:Any,<:AbstractFill}, y::AbstractVector)
+    require_one_based_indexing(x, y)
+    l,u = bandwidths(A)
+    l == -u || return _dot(x, A, y)
+
+    (axes(x)..., axes(y)...) == axes(A) || throw(DimensionMismatch())
+    T = typeof(dot(first(x), first(A), first(y)))
+    Av = unique_value(A.data)
+    iszero(Av) && return zero(T)
+
+    M,N = size(A)
+    @inbounds begin
+        xv = view(x, max(1,l+1):min(M,N+l))
+        yv = view(y, max(1,u+1):min(M+u,N))
+
+        Av*dot(xv, yv)
+    end
+end

--- a/src/banded/dot.jl
+++ b/src/banded/dot.jl
@@ -1,5 +1,6 @@
 function _dot(x::AbstractVector, A::BandedMatrix, y::AbstractVector)
     require_one_based_indexing(x, y)
+    # This should include a message but matches LinearAlgebra.dot
     (axes(x)..., axes(y)...) == axes(A) || throw(DimensionMismatch())
     l,u = bandwidths(A)
     M = size(A,1)
@@ -28,6 +29,7 @@ function dot(x::AbstractVector, A::BandedMatrix{<:Any,<:AbstractFill}, y::Abstra
     l,u = bandwidths(A)
     l == -u || return _dot(x, A, y)
 
+    # This should include a message but matches LinearAlgebra.dot
     (axes(x)..., axes(y)...) == axes(A) || throw(DimensionMismatch())
     T = typeof(dot(first(x), first(A), first(y)))
     Av = unique_value(A.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Test
 include("test_banded.jl")
 include("test_subarray.jl")
 include("test_linalg.jl")
+include("test_dot.jl")
 include("test_broadcasting.jl")
 include("test_indexing.jl")
 include("test_bandedlu.jl")

--- a/test/test_dot.jl
+++ b/test/test_dot.jl
@@ -1,0 +1,36 @@
+using BandedMatrices, LinearAlgebra, FillArrays, Test
+import BandedMatrices: _BandedMatrix
+
+@testset "dot(x, A::BandedMatrix, y)" begin
+    @testset "Single, constant diagonal" begin
+        for (m,n,l) in [(100,15,5),(15,100,-5)]
+            S = _BandedMatrix(0.1Ones{Int}(1,n), Base.OneTo(m), l, -l)
+            MS = Matrix(S)
+
+            a = rand(ComplexF64, m)
+            b = rand(ComplexF64, n)
+
+            v = dot(a, MS, b)
+            ref = dot(a, S, b)
+            @test v ≈ ref rtol=1e-14
+        end
+    end
+
+    @testset "Multiple, random diagonals" begin
+        for cols in [2000,500]
+            for (l,u) in [(3,-1), (1,1), (-1,3)]
+                S = _BandedMatrix(rand(3,cols), Base.OneTo(1000), l, u)
+                MS = Matrix(S)
+                m,n = size(S)
+
+                a = rand(ComplexF64, m)
+                b = rand(ComplexF64, n)
+
+                v = dot(a, S, b)
+                ref = dot(a, MS, b)
+
+                @test v ≈ ref rtol=1e-14
+            end
+        end
+    end
+end

--- a/test/test_dot.jl
+++ b/test/test_dot.jl
@@ -1,7 +1,9 @@
 using BandedMatrices, LinearAlgebra, FillArrays, Test
 import BandedMatrices: _BandedMatrix
+using Random
 
 @testset "dot(x, A::BandedMatrix, y)" begin
+    Random.seed!(0)
     @testset "Single, constant diagonal" begin
         for (m,n,l) in [(100,15,5),(15,100,-5)]
             S = _BandedMatrix(0.1Ones{Int}(1,n), Base.OneTo(m), l, -l)


### PR DESCRIPTION
This PR ensures that only the non-zero elements of `A`, and hence the only the correct subranges of `x` and `y` are looped over. For matrices with a a single, constant diagonal from `FillArrays`, such as the ones we get from the restriction matrices in ContinuumArrays.jl, it reduces to a dot product between views of `x` and `y`.

The benchmarks are more impressive for larger matrices, but you get the idea:

```julia
julia> (m,n,l) = (1000,150,5)
(1000, 150, 5)

julia> S = BandedMatrices._BandedMatrix(0.1Ones{Int}(1,n), Base.OneTo(m), l, -l)
1000×150 BandedMatrix{Float64,Fill{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},Base.OneTo{Int64}}:
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
 0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.1   ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
 ⋮                        ⋮                        ⋮                        ⋱  ⋮                        ⋮                        ⋮
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅       ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅

julia> MS = Matrix(S);

julia> a = rand(ComplexF64, m);

julia> b = rand(ComplexF64, n);

julia> @benchmark(dot(a, S, b))
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     94.432 ns (0.00% GC)
  median time:      98.374 ns (0.00% GC)
  mean time:        114.181 ns (1.27% GC)
  maximum time:     2.978 μs (96.26% GC)
  --------------
  samples:          10000
  evals/sample:     919

julia> @benchmark(dot(a, MS, b))
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     39.229 μs (0.00% GC)
  median time:      40.518 μs (0.00% GC)
  mean time:        45.278 μs (0.00% GC)
  maximum time:     187.329 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```