### PR TITLE
mention colrange and rowrange in docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,6 +102,8 @@ band
 BandRange
 ```
 
+To loop over the nonzero elements of a BandedMatrix, you can use `colrange(A, c)` and `rowrange(A, r)`.
+
 
 
 ## Creating symmetric banded matrices


### PR DESCRIPTION
Added a sentence to the docs mentioning the exported `colrange` and `rowrange`.