### PR TITLE
Fix urls in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Julia package for representing banded matrices
 [![Build Status](https://github.com/JuliaMatrices/BandedMatrices.jl/workflows/CI/badge.svg)](https://github.com/JuliaMatrices/BandedMatrices.jl/actions)
 
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaMatrices.github.io/BandedMatrices.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaMatrices.github.io/BandedMatrices.jl/latest)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaMatrices.github.io/BandedMatrices.jl/dev)
 [![codecov](https://codecov.io/gh/JuliaMatrices/BandedMatrices.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaMatrices/BandedMatrices.jl)
 
 
@@ -23,7 +23,7 @@ BandedMatrix(-1=> 1:5, 2=>1:3)     # creates a 5 x 5 banded matrix version of di
 BandedMatrix((-1=> 1:5, 2=>1:3), (n,m))     # creates an n x m banded matrix with 1 sub-diagonals and u super-diagonals with the specified diagonals
 BandedMatrix((-1=> 1:5, 2=>1:3), (n,m), (l,u))     # creates an n x m banded matrix with l sub-diagonals and u super-diagonals with the specified diagonals
 ```
-For more examples, see [the documentation](http://juliamatrices.github.io/BandedMatrices.jl/latest/#Creating-banded-matrices-1).
+For more examples, see [the documentation](https://juliamatrices.github.io/BandedMatrices.jl/dev/#Creating-banded-matrices).
 
 Specialized algebra routines are overriden, include `*` and `\`:
 


### PR DESCRIPTION
The [latest document](https://juliamatrices.github.io/BandedMatrices.jl/latest/) is not the latest. This PR fixes the URLs to `dev` instead of `latest`.