### PR TITLE
Fix Julia master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '^1.8.0-0'          
+          - nightly
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - nightly
+          - '^1.8.0-0'          
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17"
+version = "0.17.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -5,8 +5,7 @@ import Base: axes, axes1, getproperty, iterate, tail
 import LinearAlgebra: BlasInt, BlasReal, BlasFloat, BlasComplex, axpy!,
                         checksquare, adjoint, transpose, AdjOrTrans, HermOrSym,
                         _chol!, rot180, dot
-import LinearAlgebra.BLAS: libblas
-import LinearAlgebra.LAPACK: liblapack, chkuplo, chktrans
+import LinearAlgebra.LAPACK: chkuplo, chktrans
 import LinearAlgebra: cholesky, cholesky!, cholcopy, norm, diag, eigvals!, eigvals, eigen!, eigen,
             qr, qr!, axpy!, ldiv!, mul!, lu, lu!, ldlt, ldlt!, AbstractTriangular,
             chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, logabsdet,
@@ -40,6 +39,8 @@ import ArrayLayouts: MemoryLayout, transposelayout, triangulardata,
 
 import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros, unique_value
 
+const libblas = Base.libblas_name
+const liblapack = Base.liblapack_name
 
 export BandedMatrix,
        bandrange,


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/44360, `BLAS.libblas` and `LAPACK.liblapack` were removed. Thus BandedMatrices does not work with Julia nightlies currently, which causes test errors e.g. in PDMats (see e.g. https://github.com/JuliaStats/PDMats.jl/runs/6696362323?check_suite_focus=true).

https://github.com/JuliaLang/julia/pull/44379 added `Base.libblas_name` and `Base.liblapack_name` which can be used instead (see https://github.com/FluxML/NNlib.jl/pull/396 and https://github.com/FluxML/NNlib.jl/pull/396#issuecomment-1058364057).