### PR TITLE
`eigen` for `Symmetric` with mismatched parent bandwidths

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.3"
+version = "0.17.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -53,7 +53,7 @@ function eigen!(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix
     AB = symbandeddata(A)
     BB = symbandeddata(B)
     sbgst!('V', A.uplo, N, KA, KB, AB, BB, Q, WORK)
-    any(x -> isnan(x), A) && error("NaN found in the standard form of A")
+    any(isnan, A) && error("NaN found in the standard form of A")
     Λ, W = eigen!(A)
     GeneralizedEigen(Λ, BandedGeneralizedEigenvectors(S, Q, W))
 end

--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -52,6 +52,7 @@ function eigen!(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix
     AB = symbandeddata(A)
     BB = symbandeddata(B)
     sbgst!('V', A.uplo, N, KA, KB, AB, BB, Q, WORK)
+    any(x -> isnan(x), A) && error("NaN found in the standard form of A")
     Λ, W = eigen!(A)
     GeneralizedEigen(Λ, BandedGeneralizedEigenvectors(S, Q, W))
 end

--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -43,6 +43,7 @@ function eigen!(A::Symmetric{T,<:BandedMatrix{T}}) where T <: Real
 end
 
 function eigen!(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix{T}}) where T <: Real
+    isdiag(A) || isdiag(B) || symmetricuplo(A) == symmetricuplo(B) || throw(ArgumentError("uplo of matrices do not match"))
     S = splitcholesky!(B)
     N = size(A, 1)
     KA = bandwidth(A)

--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -24,7 +24,10 @@ compress(F::Eigen{T, T, BandedEigenvectors{T}, Vector{T}}) where T = convert(Eig
 compress(F::GeneralizedEigen{T, T, BandedGeneralizedEigenvectors{T}, Vector{T}}) where T = convert(GeneralizedEigen{T, T, Matrix{T}, Vector{T}}, F)
 
 eigen(A::Symmetric{T,<:BandedMatrix{T}}) where T <: Real = eigen!(copy(A))
-eigen(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix{T}}) where T <: Real = eigen!(copy(A), copy(B))
+function eigen(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix{T}}) where T <: Real
+    AA = _copy_bandedsym(A, B)
+    eigen!(AA, copy(B))
+end
 
 function eigen!(A::Symmetric{T,<:BandedMatrix{T}}) where T <: Real
     N = size(A, 1)

--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -53,7 +53,7 @@ function eigen!(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix
     AB = symbandeddata(A)
     BB = symbandeddata(B)
     sbgst!('V', A.uplo, N, KA, KB, AB, BB, Q, WORK)
-    any(isnan, A) && error("NaN found in the standard form of A")
+    any(isnan, A) && throw(ArgumentError("NaN found in the standard form of A"))
     Λ, W = eigen!(A)
     GeneralizedEigen(Λ, BandedGeneralizedEigenvectors(S, Q, W))
 end

--- a/src/symbanded/symbanded.jl
+++ b/src/symbanded/symbanded.jl
@@ -158,17 +158,20 @@ function copyto!(A::Symmetric{<:Number,<:BandedMatrix}, B::Symmetric{<:Number,<:
     size(A) == size(B) || throw(ArgumentError("sizes of A and B must match"))
     bandwidth(A) >= bandwidth(B) || throw(ArgumentError("bandwidth of A must exceed that of B"))
     A .= zero(eltype(A))
-    Ap = parent(A)
-    Bp = parent(B)
     SAuplo = symmetricuplo(A)
     SBuplo = symmetricuplo(B)
     if SAuplo == SBuplo
+        ASdata = symbandeddata(A)
+        BSdata = symbandeddata(B)
         if SAuplo == 'L'
-            LowerTriangular(Ap) .= LowerTriangular(Bp)
+            ASdata[axes(BSdata)...] = BSdata
         else
-            UpperTriangular(Ap) .= UpperTriangular(Bp)
+            nrowsskip = size(ASdata,1) - size(BSdata,1)
+            ASdata[axes(BSdata,1) .+ nrowsskip, axes(BSdata,2)] = BSdata
         end
     else
+        Ap = parent(A)
+        Bp = parent(B)
         if SAuplo == 'L'
             LowerTriangular(Ap) .= LowerTriangular(transpose(Bp))
         else

--- a/src/symbanded/symbanded.jl
+++ b/src/symbanded/symbanded.jl
@@ -172,11 +172,15 @@ function copyto_bandedsym!(A::Symmetric{<:Number,<:BandedMatrix}, B::Symmetric{<
     return A
 end
 
-function eigvals(A::Symmetric{<:Any,<:BandedMatrix}, B::Symmetric{<:Any,<:BandedMatrix})
-    AA = if bandwidth(A) >= bandwidth(B)
+function _copy_bandedsym(A, B)
+    if bandwidth(A) >= bandwidth(B)
         copy(A)
     else
         copyto_bandedsym!(similar(B), A)
     end
+end
+
+function eigvals(A::Symmetric{<:Any,<:BandedMatrix}, B::Symmetric{<:Any,<:BandedMatrix})
+    AA = _copy_bandedsym(A, B)
     eigvals!(AA, copy(B))
 end

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -110,14 +110,22 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     end
 
     @testset "eigen with mismatched parent bandwidths" begin
-        A = BandedMatrix(0=>ones(5), 3=>ones(2))
-        B = BandedMatrix(-1=>ones(4), 0=>2ones(5), 1=>ones(4))
-        SA = Symmetric(A, :L)
-        SB = Symmetric(B, :L)
-        λS, VS = eigen(SA, SB)
-        λ, V = eigen(Matrix(SA), Matrix(SB))
-        @test λS ≈ λ ≈ eigvals(SA, SB)
-        @test mapreduce((x,y) -> isapprox(abs.(x), abs.(y)), &, eachcol(V), eachcol(VS))
+        for (A, uploA) in Any[
+                (BandedMatrix(0=>ones(5), 3=>ones(2)), :L),
+                (BandedMatrix(0=>ones(5), -3=>ones(2)), :U),
+                ]
+            SA = Symmetric(A, uploA)
+            for (B, uploB) in Any[
+                    (BandedMatrix(-1=>ones(4), 0=>2ones(5)), :L),
+                    (BandedMatrix(0=>2ones(5), 1=>ones(4)), :U),
+                    ]
+                SB = Symmetric(B, uploB)
+                λS, VS = eigen(SA, SB)
+                λ, V = eigen(Matrix(SA), Matrix(SB))
+                @test λS ≈ λ ≈ eigvals(SA, SB)
+                @test mapreduce((x,y) -> isapprox(abs.(x), abs.(y)), &, eachcol(V), eachcol(VS))
+            end
+        end
     end
 end
 

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -110,21 +110,33 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     end
 
     @testset "eigen with mismatched parent bandwidths" begin
-        for (A, uploA) in Any[
-                (BandedMatrix(0=>ones(5), 3=>ones(2)), :L),
-                (BandedMatrix(0=>ones(5), -3=>ones(2)), :U),
+        # A is diagonal
+        function eigencheck(SA, SB)
+            λS, VS = eigen(SA, SB)
+            λ, V = eigen(Matrix(SA), Matrix(SB))
+            @test λS ≈ λ ≈ eigvals(SA, SB)
+            @test mapreduce((x,y) -> isapprox(abs.(x), abs.(y)), &, eachcol(V), eachcol(VS))
+        end
+        @testset for (A, uploA) in Any[
+                    (BandedMatrix(0=>ones(5), 3=>ones(2)), :L),
+                    (BandedMatrix(0=>ones(5), -3=>ones(2)), :U),
                 ]
             SA = Symmetric(A, uploA)
-            for (B, uploB) in Any[
-                    (BandedMatrix(-1=>ones(4), 0=>2ones(5)), :L),
-                    (BandedMatrix(0=>2ones(5), 1=>ones(4)), :U),
+            @testset for (B, uploB) in Any[
+                        (BandedMatrix(-1=>ones(4), 0=>2ones(5)), :L),
+                        (BandedMatrix(0=>2ones(5), 1=>ones(4)), :U),
                     ]
                 SB = Symmetric(B, uploB)
-                λS, VS = eigen(SA, SB)
-                λ, V = eigen(Matrix(SA), Matrix(SB))
-                @test λS ≈ λ ≈ eigvals(SA, SB)
-                @test mapreduce((x,y) -> isapprox(abs.(x), abs.(y)), &, eachcol(V), eachcol(VS))
+                eigencheck(SA, SB)
             end
+        end
+        # A is non-diagonal. In this case, uplo must match
+        @testset for uplo in [:L, :U]
+            A = BandedMatrix(-1=>fill(0.1,3), 0=>4ones(5), 1=>fill(0.1,3))
+            SA = Symmetric(A, uplo)
+            B = BandedMatrix(0=>2ones(5), (uplo == :U ? 1 : -1)=>ones(4))
+            SB = Symmetric(B, uplo)
+            eigencheck(SA, SB)
         end
     end
 end

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -109,12 +109,15 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
         @test V'Matrix(B)*V ≈ I
     end
 
-    @testset "copyto! with mismatched parent bandwidths" begin
+    @testset "eigen with mismatched parent bandwidths" begin
         A = BandedMatrix(0=>ones(5), 3=>ones(2))
         B = BandedMatrix(-1=>ones(4), 0=>2ones(5), 1=>ones(4))
         SA = Symmetric(A, :L)
         SB = Symmetric(B, :L)
-        @test eigvals(SA, SB) ≈ eigvals(Matrix(SA), Matrix(SB))
+        λS, VS = eigen(SA, SB)
+        λ, V = eigen(Matrix(SA), Matrix(SB))
+        @test λS ≈ λ ≈ eigvals(SA, SB)
+        @test mapreduce((x,y) -> isapprox(abs.(x), abs.(y)), &, eachcol(V), eachcol(VS))
     end
 end
 

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -108,6 +108,14 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
         @test V'Matrix(A)*V ≈ Diagonal(Λ)
         @test V'Matrix(B)*V ≈ I
     end
+
+    @testset "copyto! with mismatched parent bandwidths" begin
+        A = BandedMatrix(0=>ones(5), 3=>ones(2))
+        B = BandedMatrix(-1=>ones(4), 0=>2ones(5), 1=>ones(4))
+        SA = Symmetric(A, :L)
+        SB = Symmetric(B, :L)
+        @test eigvals(SA, SB) ≈ eigvals(Matrix(SA), Matrix(SB))
+    end
 end
 
 @testset "Hermitian" begin


### PR DESCRIPTION
Implement `copyto!` for symmetric banded matrices. The new function is then used in `eigvals` and `eigen`. The following works with this change:
```julia
julia> A = BandedMatrix(0=>ones(5), 3=>ones(2))
5×5 BandedMatrix{Float64} with bandwidths (0, 3):
 1.0  0.0  0.0  1.0   ⋅ 
  ⋅   1.0  0.0  0.0  1.0
  ⋅    ⋅   1.0  0.0  0.0
  ⋅    ⋅    ⋅   1.0  0.0
  ⋅    ⋅    ⋅    ⋅   1.0

julia> B = BandedMatrix(-1=>ones(4), 0=>2ones(5), 1=>ones(4))
5×5 BandedMatrix{Float64} with bandwidths (1, 1):
 2.0  1.0   ⋅    ⋅    ⋅ 
 1.0  2.0  1.0   ⋅    ⋅ 
  ⋅   1.0  2.0  1.0   ⋅ 
  ⋅    ⋅   1.0  2.0  1.0
  ⋅    ⋅    ⋅   1.0  2.0

julia> SA = Symmetric(A, :L)
5×5 Symmetric{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}}:
 1.0   ⋅    ⋅    ⋅    ⋅ 
  ⋅   1.0   ⋅    ⋅    ⋅ 
  ⋅    ⋅   1.0   ⋅    ⋅ 
  ⋅    ⋅    ⋅   1.0   ⋅ 
  ⋅    ⋅    ⋅    ⋅   1.0

julia> SB = Symmetric(B, :L)
5×5 Symmetric{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}}:
 2.0  1.0   ⋅    ⋅    ⋅ 
 1.0  2.0  1.0   ⋅    ⋅ 
  ⋅   1.0  2.0  1.0   ⋅ 
  ⋅    ⋅   1.0  2.0  1.0
  ⋅    ⋅    ⋅   1.0  2.0

julia> eigvals(SA, SB)
5-element Vector{Float64}:
 0.2679491924311229
 0.3333333333333335
 0.5000000000000001
 0.9999999999999998
 3.7320508075688807

julia> eigen(SA, SB)
GeneralizedEigen{Float64, Float64, BandedMatrices.BandedGeneralizedEigenvectors{Float64, Symmetric{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}}}, Vector{Float64}}
values:
5-element Vector{Float64}:
 0.2679491924311228
 0.33333333333333337
 0.5
 0.9999999999999989
 3.732050807568877
vectors:
5×5 BandedMatrices.BandedGeneralizedEigenvectors{Float64, Symmetric{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}}}:
 0.149429   0.288675      0.408248     -0.5           0.557678
 0.258819   0.288675     -2.26623e-16   0.5          -0.965926
 0.298858   6.18095e-17  -0.408248     -3.21172e-16   1.11536
 0.258819  -0.288675      0.0          -0.5          -0.965926
 0.149429  -0.288675      0.408248      0.5           0.557678
```