### PR TITLE
Fix `diag` if data excludes the principal diagonal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.5"
+version = "0.17.6"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -693,11 +693,14 @@ function fill!(A::BandedMatrix{T}, x) where T
     A
 end
 
-function diag(A::BandedMatrix{T}) where {T}
-    n=size(A,1)
-    @assert n==size(A,2)
+function diag(A::BandedMatrix{T}, k::Integer = 0) where {T}
+    n = LinearAlgebra.checksquare(A) - abs(k)
 
-    vec(A.data[A.u+1,1:n])
+    if -A.l <= k <= A.u
+        convert(Vector{T}, vec(A.data[A.u-k+1,range(max(k, 0) + begin, length=n)]))
+    else
+        zeros(T, max(n, 0))
+    end
 end
 
 

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -264,5 +264,24 @@ import BandedMatrices: BandedColumns, _BandedMatrix
         @test factorize(A) isa QR
         @test A \ b ≈ Matrix(A) \ b
     end
+
+    @testset "diag" begin
+        for B in [BandedMatrix(1=>ones(5), 2=>ones(4)),
+                    BandedMatrix(-1=>ones(5), -2=>ones(4))]
+            @test all(iszero, diag(B))
+        end
+        for B in [BandedMatrix(0=>[1:6;], 2=>fill(2,4)),
+                    BandedMatrix(0=>[1:6;], -2=>fill(2,4))]
+            @test diag(B) == 1:6
+        end
+        @testset "kth diagonal" begin
+            n = 6
+            B = BandedMatrix([k=>rand(n-abs(k)) for k in -2:2]...)
+            M = Matrix(B)
+            @testset for k in -n:n
+                @test diag(B, k) == diag(M, k)
+            end
+        end
+    end
 end
 


### PR DESCRIPTION
Also compute the `k-th` diagonal

After this:
```julia
julia> B = BandedMatrix(1=>[1:5;], 2=>fill(2,4))
6×6 BandedMatrix{Int64} with bandwidths (-1, 2):
 ⋅  1  2  ⋅  ⋅  ⋅
 ⋅  ⋅  2  2  ⋅  ⋅
 ⋅  ⋅  ⋅  3  2  ⋅
 ⋅  ⋅  ⋅  ⋅  4  2
 ⋅  ⋅  ⋅  ⋅  ⋅  5
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅

julia> diag(B)
6-element Vector{Int64}:
 0
 0
 0
 0
 0
 0

julia> diag(B, 1)
5-element Vector{Int64}:
 1
 2
 3
 4
 5
```