### PR TITLE
Don't test on v1.8 explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '^1.8.0-0'          
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Now that v1 points to v1.8, this was duplicating the test