### PR TITLE
Run CI only on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - master
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
Since the CI tests are run for a PR anyway, this will avoid duplicate CI runs if a PR includes push to a branch on the repo. The only difference will pushing to branches without creating a PR to master won't trigger the CI.