### PR TITLE
remove unbound type parameter

### DIFF
--- a/src/banded/BandedLU.jl
+++ b/src/banded/BandedLU.jl
@@ -95,7 +95,7 @@ end
 _lu!(::AbstractBandedLayout, axes, A, pivot::Union{Val{false}, Val{true}} = Val(true); check::Bool = true) =
     banded_lufact!(A, pivot; check = check)
 
-function _lu(::AbstractBandedLayout, axes, A, pivot::Union{Val{false}, Val{true}} = Val(true); check::Bool = true) where {T<:Real}
+function _lu(::AbstractBandedLayout, axes, A, pivot::Union{Val{false}, Val{true}} = Val(true); check::Bool = true)
     l,u = bandwidths(A)
     lu!(BandedMatrix{float(eltype(A))}(A,(l,l+u)), pivot; check = check)
 end


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.