### PR TITLE
Use `Aqua` to ensure project quality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.6"
+version = "0.17.7"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/Project.toml
+++ b/Project.toml
@@ -10,14 +10,16 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+Aqua = "0.5"
 ArrayLayouts = "0.8"
 FillArrays = "0.13"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Base64", "Test", "GenericLinearAlgebra"]
+test = ["Aqua", "Base64", "Test", "GenericLinearAlgebra"]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A Julia package for representing banded matrices
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaMatrices.github.io/BandedMatrices.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaMatrices.github.io/BandedMatrices.jl/dev)
 [![codecov](https://codecov.io/gh/JuliaMatrices/BandedMatrices.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaMatrices/BandedMatrices.jl)
-
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 
 This package supports representing banded matrices by only the entries on the
-bands.  
+bands.
 
 One can create banded matrices of type `BandedMatrix` as follows:
 

--- a/src/banded/BandedLU.jl
+++ b/src/banded/BandedLU.jl
@@ -95,7 +95,7 @@ end
 _lu!(::AbstractBandedLayout, axes, A, pivot::Union{Val{false}, Val{true}} = Val(true); check::Bool = true) =
     banded_lufact!(A, pivot; check = check)
 
-function _lu(::AbstractBandedLayout, axes, A, pivot::Union{Val{false}, Val{true}} = Val(true); check::Bool = true) where {T<:Real}
+function _lu(::AbstractBandedLayout, axes, A, pivot::Union{Val{false}, Val{true}} = Val(true); check::Bool = true)
     l,u = bandwidths(A)
     lu!(BandedMatrix{float(eltype(A))}(A,(l,l+u)), pivot; check = check)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,11 @@ using LinearAlgebra
 using SparseArrays
 using Test
 
+using Aqua
+@testset "Project quality" begin
+    Aqua.test_all(BandedMatrices, ambiguities=false)
+end
+
 include("test_banded.jl")
 include("test_subarray.jl")
 include("test_linalg.jl")


### PR DESCRIPTION
Removes an unbound type parameter in a `_lu` method.