### PR TITLE
Update tagbot with write permission

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,14 +1,17 @@
 name: TagBot
 on:
-  issue_comment:  # THIS BIT IS NEW
+  issue_comment:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  contents: write
 jobs:
   TagBot:
-    # THIS 'if' LINE IS NEW
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    # NOTHING BELOW HAS CHANGED
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
Copied from https://github.com/JuliaRegistries/TagBot#setup. @hyrodium let's see if this helps in any way with tagbot being able to run the documenter action